### PR TITLE
Bump the version of copy_env to support hokusai

### DIFF
--- a/Formula/copy_env.rb
+++ b/Formula/copy_env.rb
@@ -1,8 +1,8 @@
 class CopyEnv < Formula
-  desc "Automate dotenv setup with values from Heroku"
-  homepage "https://github.com/jonallured/copy_env"
-  url "https://github.com/jonallured/copy_env/archive/v0.0.1.tar.gz"
-  sha256 "089de16845a5a38ae93ba9427e331598b3794fc92e3ccfcd434cd33bc3b6fa3b"
+  desc 'Automate dotenv setup with values from Heroku'
+  homepage 'https://github.com/jonallured/copy_env'
+  url 'https://github.com/jonallured/copy_env/archive/v0.0.2.tar.gz'
+  sha256 '7983c2a53c89dd6cf0b5e390a8d3c1f6d05ce97817ced9a6fc24db58ce184b5c'
 
   def install
     bin.install 'copy_env'


### PR DESCRIPTION
This PR points our brew tap at the latest version of `copy_env` where @anandaroop was nice enough to update the script to support hokusai. Because I always forget how to do this, I'm just going to document the steps I used here:

* go to the project and create a new tag
* update the url here to reflect that new tag
* get the sha with something like this:

```
$ curl path/to/file.tar.gz -o file.tar.gz
$ shasum -a 256 file.tar.gz
eiornijerfoienrfvoierjfoijerfhfioiaewfhr file.tar.gz
```

Then you can just paste that sucker into the formula file.