### PR TITLE
bump hokusai to v0.5.7

### DIFF
--- a/Formula/hokusai.rb
+++ b/Formula/hokusai.rb
@@ -1,9 +1,9 @@
 class Hokusai < Formula
   desc 'Hokusai is a Docker + Kubernetes CLI for application developers'
   homepage 'https://github.com/artsy/hokusai'
-  url 'https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-0.5.6-Darwin-x86_64.tar.gz'
-  sha256 '519bf22236fcd8f68cedf9a79836b5e44b068e6fbfc9d8164ca7a31f817e930f'
-  version '0.5.6'
+  url 'https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-0.5.7-Darwin-x86_64.tar.gz'
+  sha256 'a5c71bdad68cb8850961529fe093de8617c43d272033c33b0cbd88b21827ad17'
+  version '0.5.7'
 
   def install
     bin.install 'hokusai'


### PR DESCRIPTION
https://github.com/artsy/hokusai/pull/171

@jonallured do we have to re-init the cask or can users just do a `brew upgrade hokusai`?