### PR TITLE
Change java dependency to openjdk

### DIFF
--- a/Formula/elasticsearch@5.6.rb
+++ b/Formula/elasticsearch@5.6.rb
@@ -10,7 +10,7 @@ class ElasticsearchAT56 < Formula
 
   keg_only :versioned_formula
 
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"


### PR DESCRIPTION
Problem:

getting:
```
Invalid formula: /usr/local/Homebrew/Library/Taps/artsy/homebrew-formulas/Formula/elasticsearch@5.6.rb
elasticsearch@5.6: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the artsy/formulas tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/artsy/homebrew-formulas/Formula/elasticsearch@5.6.rb:13
```

Made this change and ran `brew install ./elasticsearch@5.6.rb` and it installed elasticsearch@5.6 without error.