### PR TITLE
Remove :unneeded

### DIFF
--- a/Formula/elasticsearch@5.6.rb
+++ b/Formula/elasticsearch@5.6.rb
@@ -6,8 +6,6 @@ class ElasticsearchAT56 < Formula
   url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.tar.gz"
   sha256 "6b035a59337d571ab70cea72cc55225c027ad142fbb07fd8984e54261657c77f"
 
-  bottle :unneeded
-
   keg_only :versioned_formula
 
   depends_on "openjdk@8"


### PR DESCRIPTION
I got the following warning when I ran `brew outdated`.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the artsy/formulas tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/artsy/homebrew-formulas/Formula/elasticsearch@5.6.rb:9
```

Calling `bottle :unneeded` is deprecated and it looks like we can just remove it.
https://github.com/Homebrew/homebrew-core/pull/75946