### PR TITLE
fix: update formula to use supported service definition

### DIFF
--- a/Formula/elasticsearch@6.rb
+++ b/Formula/elasticsearch@6.rb
@@ -82,40 +82,13 @@ class ElasticsearchAT6 < Formula
         Config:  #{etc}/elasticsearch/
       EOS
     end
-  
-    plist_options manual: "elasticsearch"
-  
-    def plist
-      <<~EOS
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-          <dict>
-            <key>KeepAlive</key>
-            <false/>
-            <key>Label</key>
-            <string>#{plist_name}</string>
-            <key>ProgramArguments</key>
-            <array>
-              <string>#{opt_bin}/elasticsearch</string>
-            </array>
-            <key>EnvironmentVariables</key>
-            <dict>
-            <!-- customize to address https://github.com/Homebrew/homebrew-core/issues/100260 -->
-            <key>JAVA_HOME</key>
-            <string>'/usr/libexec/java_home -v 17'</string>
-            </dict>
-            <key>RunAtLoad</key>
-            <true/>
-            <key>WorkingDirectory</key>
-            <string>#{var}</string>
-            <key>StandardErrorPath</key>
-            <string>#{var}/log/elasticsearch.log</string>
-            <key>StandardOutPath</key>
-            <string>#{var}/log/elasticsearch.log</string>
-          </dict>
-        </plist>
-      EOS
+
+    service do
+      run opt_bin/"elasticsearch"
+      working_dir var
+      environment_variables JAVA_HOME: '/usr/libexec/java_home -v 17'
+      log_path var/"log/elasticsearch.log"
+      error_log_path var/"log/elasticsearch.log"
     end
   
     test do


### PR DESCRIPTION
Running the gravity setup script I got this error: 

```
Installing artsy/formulas/elasticsearch@6
Warning: 'artsy/formulas/elasticsearch@6' formula is unreadable: artsy/formulas/elasticsearch@6: undefined method `plist_options' for Formulary::FormulaNamespacefaf1a736787bb16d807e9d7c8aa30972e7cd8a4f6fbf7842d53f821e8e306600::ElasticsearchAT6:Class
Error: artsy/formulas/elasticsearch@6: undefined method `plist_options' for Formulary::FormulaNamespacefaf1a736787bb16d807e9d7c8aa30972e7cd8a4f6fbf7842d53f821e8e306600::ElasticsearchAT6:Class
Installing artsy/formulas/elasticsearch@6 has failed!
```

Turns out plist_options was deprecated, then removed in favor of a new service block: 
https://github.com/Homebrew/brew/pull/14382/files

PR based on this similar elasticsearch pr:
https://github.com/elastic/homebrew-tap/pull/144/files  

plus the docs here to set our custom variables: 
https://docs.brew.sh/Formula-Cookbook

worked editing locally and reinstalling but anyone more familiar with homebrew formulae's 👀 would be appreciated. 
