### PR TITLE
fix: avoid noisy security warnings when developing and running tests locally

### DIFF
--- a/Formula/elasticsearch-full@7.17.rb
+++ b/Formula/elasticsearch-full@7.17.rb
@@ -32,6 +32,7 @@ class ElasticsearchFullAT717 < Formula
 
         # Disable xpack.ml features on mac due to mismatched signatures/paths
         s.sub!(%r{\Z}, "\nxpack.ml.enabled: false\n")
+        s.sub!(%r{\Z}, "\nxpack.security.enabled: false\n")
       end
   
       inreplace "#{libexec}/config/jvm.options", %r{logs/gc.log}, "#{var}/log/elasticsearch/gc.log"


### PR DESCRIPTION
Similar to https://github.com/artsy/gravity/pull/18145, this disables xpack security features locally to avoid noisy security warnings in dev and test envs.